### PR TITLE
Enable clang64/32 support from within msys2 in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -117,7 +117,7 @@ if [[ $UNAME == *"MINGW"* ]]; then
     cp /$mingw_prefix/bin/libc++.dll $install_dir
   else
     my_os=win32
-    cp /$mingw_prefix/bin/libgcc_s_dw2-1.dll $install_dir
+    cp /$mingw_prefix/bin/libc++.dll $install_dir
   fi
   cp /$mingw_prefix/bin/libwinpthread-1.dll $install_dir
   cp /$mingw_prefix/bin/SDL2.dll $install_dir

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,11 @@ if [[ $UNAME == *"MINGW"* ]]; then
   else
     mingw_prefix="mingw32"
   fi
+  if [[ $UNAME == *"CLANG64"* ]]; then
+    mingw_prefix="clang64"
+  else
+    mingw_prefix="clang32"
+  fi
 elif [[ $UNAME == *"Darwin"* ]]; then
   suffix=".dylib"
   qt_version=$(ls /usr/local/Cellar/qt@5)
@@ -101,6 +106,15 @@ if [[ $UNAME == *"MINGW"* ]]; then
   if [[ $UNAME == *"MINGW64"* ]]; then
     my_os=win64
     cp /$mingw_prefix/bin/libgcc_s_seh-1.dll $install_dir
+    cp /$mingw_prefix/bin/libstdc++-6.dll $install_dir
+  else
+    my_os=win32
+    cp /$mingw_prefix/bin/libgcc_s_dw2-1.dll $install_dir
+    cp /$mingw_prefix/bin/libstdc++-6.dll $install_dir
+  fi
+  if [[ $UNAME == *"CLANG64"* ]]; then
+    my_os=win64
+    cp /$mingw_prefix/bin/libc++.dll $install_dir
   else
     my_os=win32
     cp /$mingw_prefix/bin/libgcc_s_dw2-1.dll $install_dir
@@ -110,7 +124,6 @@ if [[ $UNAME == *"MINGW"* ]]; then
   cp /$mingw_prefix/bin/SDL2_net.dll $install_dir
   cp /$mingw_prefix/bin/libpng16-16.dll $install_dir
   cp /$mingw_prefix/bin/libglib-2.0-0.dll $install_dir
-  cp /$mingw_prefix/bin/libstdc++-6.dll $install_dir
   cp /$mingw_prefix/bin/zlib1.dll $install_dir
   cp /$mingw_prefix/bin/libintl-8.dll $install_dir
   cp /$mingw_prefix/bin/libpcre-1.dll $install_dir


### PR DESCRIPTION
This should allow building within msys2 support of clang32/64, however things within the mupen64plus core etc will need some addressing before it can be properly built like clang doesn't support -version-script or -Bsymbolic and I know that at least with the version script that it's used to only export the needed symbols, but I'm not sure how to go about that in clang just yet so that's why this is a draft for now, unless there's no objection to having it merged and the rest dealt with later?