### PR TITLE
Add link to last working macOS version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # m64p
 https://m64p.github.io
 
-**Downloads found here: https://github.com/m64p/m64p/releases**
+**Downloads for Windows and Linux found here: https://github.com/m64p/m64p/releases**
+
+> **macOS users:** The last working macOS release is [Feb232021](https://github.com/m64p/m64p/releases/tag/Feb232021).
+>
+> *This old version is not officially supported anymore, so do not report issues with it.*
+>
+> The build is not signed with an Apple Developer certificate and notarized,
+> so you may need to right-click it and choose **Open** twice to be able to run it.
 
 # Wiki
 https://github.com/m64p/m64p/wiki


### PR DESCRIPTION
While this build is quite outdated by now, it's still in a good enough state to run a lot of games at fullspeed on both x86_64 and ARM CPUs (tested on 2020 M1 Mac mini).

See https://github.com/m64p/m64p/issues/152.

Note that instead of adding a note to the README, it may be better to modify the release notes for the latest release to point to the old version instead.