### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 #### Linux: **https://flathub.org/apps/details/io.github.m64p.m64p**
 
-#### Mac OS: No releases currently, require a maintainer. Please contact Logan for details if you wish to do this.
+#### Mac OS: No releases currently, requires a maintainer. See also https://github.com/Themaister/parallel-rdp/issues/20
 
 # Wiki
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
-# m64p
-https://m64p.github.io
+# m64p website
 
-**Downloads found here: https://github.com/m64p/m64p/releases**
+**https://m64p.github.io**
+
+# Downloads
+
+#### Windows: **https://github.com/m64p/m64p/releases**
+
+#### Linux: **https://flathub.org/apps/details/io.github.m64p.m64p**
+
+#### Mac OS: No releases currently, require a maintainer. Please contact Logan for details if you wish to do this.
 
 # Wiki
-https://github.com/m64p/m64p/wiki
+
+**https://github.com/m64p/m64p/wiki**


### PR DESCRIPTION
Added a link to linux Flatpak distro and a reason why Mac OS isn't currently available.